### PR TITLE
Fix macro usage through full path, and allow module level expansion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ matrix:
   include:
     - rust: 1.20.0
     - rust: stable
+      env: STABLE=1
     - rust: nightly
+      env: STABLE=1
 branches:
   only:
     - master
 script:
   - |
-      cargo build --verbose &&
-      cargo test --verbose &&
-      cargo doc -v
+      cargo build -v &&
+      cargo test -v --lib &&
+      cargo test -v --doc &&
+      cargo doc -v &&
+      ([ "$STABLE" != 1 ] || cargo test )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 /// or a pattern like `ref value`, `(x, y)` etc.
 ///
 /// Supports arbitrary many arguments.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! defmac {
     // nest matches final rule
     (@nest $name:ident ($dol:tt) => (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,30 +97,29 @@ macro_rules! defmac {
         $p1:pat $(, $p2:pat)*
     ) => {
         // `marg` is a hygienic macro argument name
-        defmac!(@nest $name ($dol) => (
+        defmac!{@nest $name ($dol) => (
             [marg $($arg)*]
             match {$dol marg} { $p1 => $($result_body)+ }
         )
-        $($p2),* )
+        $($p2),* }
     };
 
     // reverse patterns before passing them on to @nest
     // reverse patterns final rule
     (@revpats [$($args:tt)*] [$($pr:pat),*]) => {
-        defmac!(@nest $($args)* $($pr),*)
+        defmac!{@nest $($args)* $($pr),*}
     };
 
     // reverse patterns entry point and recursive rule
     (@revpats [$($args:tt)*] [$($pr:pat),*] $p1:pat $(, $p2:pat)*) => {
-        defmac!(@revpats [$($args)*] [$p1 $(, $pr)*] $($p2),*)
+        defmac!{@revpats [$($args)*] [$p1 $(, $pr)*] $($p2),*}
     };
 
     // entry point
     ($name:ident $($p1:pat),* => $result:expr) => {
-        defmac!(@revpats [$name ($) => ([] $result)] [] $($p1),*)
+        defmac!{@revpats [$name ($) => ([] $result)] [] $($p1),*}
     };
 }
-
 
 
 #[cfg(test)]
@@ -166,5 +165,13 @@ mod tests {
         let result = two!(f(), f());
         assert_eq!(result, (0, 1));
         assert_eq!(f(), 2);
+    }
+
+    // Test expansion at module level
+    defmac! { triple value => [value; 3] }
+
+    #[test]
+    fn module_macro() {
+        assert_eq!(triple!(3), [3, 3, 3]);
     }
 }

--- a/tests/cross_crate.rs
+++ b/tests/cross_crate.rs
@@ -1,0 +1,7 @@
+
+#[test]
+fn full_path() {
+    defmac::defmac! { len x => x.len() }
+
+    assert_eq!(len!(&[1, 2]), 2);
+}


### PR DESCRIPTION
1. Fix macro usage like `defmac::defmac! { .. }` with new Rust rules
2. Allow module level expansion again (was lost in version 0.2.0)